### PR TITLE
My fixes to run tempalte_builder and template merging tool

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ channels:
   - conda-forge
 dependencies:
   - astropy
-  - ctapipe==0.18.1
+  - ctapipe==0.19
   - ipython
   - jupyter
   - matplotlib

--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,29 @@
 from setuptools import setup
 
 setup(
-    name='template_builder',
-    version='2.0',
-    packages=['template_builder'],
-    package_dir={'template_builder': 'template_builder'},
-    package_data={'template_builder': ["configs/array_trigger_temp.dat",
-                                       "configs/cta-temp_run.sh",
-                                       "configs/run_sim_template",
-                                       "configs/simtel_template.cfg"],
-                  'template_builder_data': ["data/gamma_HESS_example.simhess.gz"]},
+    name="template_builder",
+    version="2.0",
+    packages=["template_builder"],
+    package_dir={"template_builder": "template_builder"},
+    package_data={
+        "template_builder": [
+            "configs/array_trigger_temp.dat",
+            "configs/cta-temp_run.sh",
+            "configs/run_sim_template",
+            "configs/simtel_template.cfg",
+        ],
+        "template_builder_data": ["data/gamma_HESS_example.simhess.gz"],
+    },
     include_package_data=True,
-    url='',
-    license='',
-    author='parsonsrd',
-    author_email='',
-    description='Creation tools for building ImPACT templates for ctapipe',
-    entry_points = {'console_scripts': ['template-fitter = template_builder.template_fitter:main']},
+    url="",
+    license="",
+    author="parsonsrd",
+    author_email="",
+    description="Creation tools for building ImPACT templates for ctapipe",
+    entry_points={
+        "console_scripts": [
+            "template-fitter = template_builder.template_fitter:main",
+            "template-merger = template_builder.merge_templates:main",
+        ]
+    },
 )

--- a/template_builder/merge_templates.py
+++ b/template_builder/merge_templates.py
@@ -1,0 +1,100 @@
+from ctapipe.core import Tool, traits
+
+from ctapipe.core.traits import List, Unicode
+
+
+from argparse import ArgumentParser
+from pathlib import Path
+
+import sys
+import gzip
+import pickle
+
+
+class TemplateMerger(Tool):
+
+    """
+    Tool to merge multiple templates dictionaries each with a different
+    subset of keys into one large template dictionary.
+    This is useful mostly because creating multiple subsets in parallel is much
+    faster computationally than directly creating one large dictionary.
+    """
+
+    input_dir = traits.Path(
+        default_value=None,
+        help="Input directory",
+        allow_none=True,
+        exists=True,
+        directory_ok=True,
+        file_ok=False,
+    ).tag(config=True)
+
+    input_files = List(
+        traits.Path(exists=True, directory_ok=False),
+        default_value=[],
+        help="Input template dictionary files",
+    ).tag(config=True)
+
+    file_pattern = Unicode(
+        default_value="*.template.gz",
+        help="Give a specific file pattern for matching files in ``input_dir``",
+    ).tag(config=True)
+
+    parser = ArgumentParser()
+    parser.add_argument("input_files", nargs="*", type=Path)
+
+    output_file = Unicode(default_value=".", help="base output file name").tag(
+        config=True
+    )
+
+    def setup(self):
+
+        # Load in all input files
+        args = self.parser.parse_args(self.extra_args)
+        self.input_files.extend(args.input_files)
+        if self.input_dir is not None:
+            self.input_files.extend(sorted(self.input_dir.glob(self.file_pattern)))
+
+        if not self.input_files:
+            self.log.critical(
+                "No input files provided, either provide --input-dir "
+                "or input files as positional arguments"
+            )
+            sys.exit(1)
+
+    def start(self):
+        self.full_template_dict = {}
+        # Open and unpickle the tempalte ditionaries
+        for input_file in self.input_files:
+            this_dict = None
+            with gzip.open(input_file, "r") as gz_inp_file:
+                this_dict = pickle.load(gz_inp_file)
+
+            for key, value in this_dict.items():
+                # We need to make sure that we have a unique template for every key.
+                # It is at this stage not obvious how to combine two templates for the same key into one.
+                # Therefore, we throw an error as soon as a key that already exists is accessed again.
+                assert (
+                    key not in self.full_template_dict.keys()
+                ), "The key {} is already in the merged template dictionary.".format(
+                    key
+                )
+                # Write the dictionary to the common dictionary.
+                self.full_template_dict[key] = value
+
+    def finish(self):
+        # Save the combined template
+        file_handler = gzip.open(self.output_file + ".template.gz", "wb")
+        pickle.dump(self.full_template_dict, file_handler)
+        file_handler.close()
+
+
+def main():
+    """run the tool"""
+
+    tool = TemplateMerger()
+    tool.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/template_builder/merge_templates.py
+++ b/template_builder/merge_templates.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import sys
 import gzip
 import pickle
+import warnings
 
 
 class TemplateMerger(Tool):
@@ -73,14 +74,16 @@ class TemplateMerger(Tool):
             for key, value in this_dict.items():
                 # We need to make sure that we have a unique template for every key.
                 # It is at this stage not obvious how to combine two templates for the same key into one.
-                # Therefore, we throw an error as soon as a key that already exists is accessed again.
-                assert (
-                    key not in self.full_template_dict.keys()
-                ), "The key {} is already in the merged template dictionary.".format(
-                    key
-                )
-                # Write the dictionary to the common dictionary.
-                self.full_template_dict[key] = value
+                # Therefore, we throw a warning as soon as a key that already exists is accessed again.
+                if key not in self.full_template_dict.keys():
+                    # Write the dictionary to the common dictionary.
+                    self.full_template_dict[key] = value
+                else:
+                    warnings.warn(
+                        "The key {} is already in the merged template dictionary.".format(
+                            key
+                        )
+                    )
 
     def finish(self):
         # Save the combined template

--- a/template_builder/nn_fitter.py
+++ b/template_builder/nn_fitter.py
@@ -262,9 +262,9 @@ class NNFitter(Component):
 
                 # Create interpolator for our template and predict amplitude
                 interpolator = RegularGridInterpolator(
-                    (y_bins, x_bins), template, bounds_error=False, fill_value=0
+                    (x_bins, y_bins), template, bounds_error=False, fill_value=0
                 )
-                prediction = interpolator((y, x))
+                prediction = interpolator((x, y))
                 prediction[prediction < 1e-6] = 1e-6
 
                 # Store the amplitude and prediction

--- a/template_builder/nn_fitter.py
+++ b/template_builder/nn_fitter.py
@@ -19,6 +19,7 @@ from template_builder.utilities import *
 from template_builder.extend_templates import *
 from tqdm import tqdm
 
+
 class NNFitter(Component):
 
     bounds = List(
@@ -32,11 +33,12 @@ class NNFitter(Component):
     ).tag(config=True)
 
     min_fit_pixels = Int(
-        default_value = 1000,
+        default_value=1000,
         help="Minimum number of pixels required to fit image",
     ).tag(config=True)
 
-    def __init__(self):
+    def __init__(self, config=None, parent=None):
+        super().__init__(config=config, parent=parent)
         return
 
     def fit_templates(self, x_pos, y_pos, amplitude):
@@ -67,7 +69,7 @@ class NNFitter(Component):
             # Skip if we do not have enough image pixels
             if len(amp) < self.min_fit_pixels:
                 continue
-                
+
             y = y_pos[key]
             x = x_pos[key]
 
@@ -77,14 +79,13 @@ class NNFitter(Component):
             # Fit with MLP
             template_output = self.perform_fit(amp, pixel_pos)
             templates_out[key] = template_output.astype(np.float32)
-            
-            #if make_variance_template:
-                # need better plan for var templates
+
+            # if make_variance_template:
+            # need better plan for var templates
 
         return templates_out
 
-    def perform_fit(self, amp, pixel_pos, 
-                    nodes=(64, 64, 64, 64, 64, 64, 64, 64, 64)):
+    def perform_fit(self, amp, pixel_pos, nodes=(64, 64, 64, 64, 64, 64, 64, 64, 64)):
         """
         Fit MLP model to individual template pixels
 
@@ -106,7 +107,7 @@ class NNFitter(Component):
         grid = np.vstack((xx.ravel(), yy.ravel()))
 
         # We expect our images to be symmetric around x=0, so we can duplicate and copy
-        # across the values 
+        # across the values
         pixel_pos_neg = np.array([pixel_pos.T[0], -1 * np.abs(pixel_pos.T[1])]).T
         pixel_pos = np.concatenate((pixel_pos, pixel_pos_neg))
         amp = np.concatenate((amp, amp))
@@ -119,35 +120,43 @@ class NNFitter(Component):
         for n in nodes[1:]:
             model.add(Dense(n, activation="relu"))
 
-        model.add(Dense(1, activation='linear'))
+        model.add(Dense(1, activation="linear"))
 
         def poisson_loss(y_true, y_pred):
-            return tensor_poisson_likelihood(y_true, y_pred, 0.5, 1.)
+            return tensor_poisson_likelihood(y_true, y_pred, 0.5, 1.0)
 
         # First we have a go at fitting our model with a mean squared loss
         # this gets us most of the way to the answer and is more stable
-        model.compile(loss="mse",
-                        optimizer="adam", metrics=['accuracy'])
-        stopping = keras.callbacks.EarlyStopping(monitor='val_loss',
-                                                    min_delta=0.0,
-                                                    patience=20,
-                                                    verbose=0, mode='auto')
-        
-        
-        model.fit(pixel_pos, amp, epochs=10000,
-                    batch_size=50000,
-                    callbacks=[stopping], validation_split=0.1, verbose=0)
+        model.compile(loss="mse", optimizer="adam", metrics=["accuracy"])
+        stopping = keras.callbacks.EarlyStopping(
+            monitor="val_loss", min_delta=0.0, patience=20, verbose=0, mode="auto"
+        )
+
+        model.fit(
+            pixel_pos,
+            amp,
+            epochs=10000,
+            batch_size=50000,
+            callbacks=[stopping],
+            validation_split=0.1,
+            verbose=0,
+        )
         weights = model.get_weights()
 
         # Then copy over the weights to a new model but with our poisson loss
         # this should get the final normalisation right
-        model.compile(loss=poisson_loss,
-                        optimizer="adam", metrics=['accuracy'])
+        model.compile(loss=poisson_loss, optimizer="adam", metrics=["accuracy"])
         model.set_weights(weights)
-        
-        model.fit(pixel_pos, amp, epochs=10000,
-                    batch_size=50000,
-                    callbacks=[stopping], validation_split=0.1, verbose=0)
+
+        model.fit(
+            pixel_pos,
+            amp,
+            epochs=10000,
+            batch_size=50000,
+            callbacks=[stopping],
+            validation_split=0.1,
+            verbose=0,
+        )
         model_pred = model.predict(grid.T, verbose=0)
 
         # Set everything outside the range of our points to zero
@@ -156,9 +165,11 @@ class NNFitter(Component):
         lin_nan = lin_range(grid.T) == 0
         model_pred[lin_nan] = 0
 
-        return model_pred.reshape((self.bins[1], self.bins[0]))
+        return model_pred.reshape((self.bins[1], self.bins[0])).T
 
-    def generate_templates(self, x, y, amplitude, time, count, total, output_file="./Template"):
+    def generate_templates(
+        self, x, y, amplitude, time, count, total, output_file="./Template"
+    ):
         """
 
         :param file_list: list
@@ -174,48 +185,54 @@ class NNFitter(Component):
         :return: dict
             Dictionary of image templates
 
-        """       
+        """
         templates = self.fit_templates(x, y, amplitude)
-        file_handler = gzip.open(output_file+".template.gz", "wb")
+        file_handler = gzip.open(output_file + ".template.gz", "wb")
         pickle.dump(templates, file_handler)
         file_handler.close()
 
-        correction_factor = self.calculate_correction_factors(x, y, amplitude, templates)
+        correction_factor = self.calculate_correction_factors(
+            x, y, amplitude, templates
+        )
         for t in templates:
             templates[t] = templates[t] * correction_factor
-        file_handler = gzip.open(output_file+"_corrected.template.gz", "wb")
+        file_handler = gzip.open(output_file + "_corrected.template.gz", "wb")
         pickle.dump(templates, file_handler)
         file_handler.close()
 
         time_slope = {}
         for key in tqdm(list(time.keys())):
             time_slope_list = time[key]
-            if len(time_slope_list) >5:
-                time_slope[key] = np.array((scipy.stats.trim_mean(time_slope_list, 0.01),  
-                                             scipy.stats.mstats.trimmed_std(time_slope_list, 0.01)))
+            if len(time_slope_list) > 5:
+                time_slope[key] = np.array(
+                    (
+                        scipy.stats.trim_mean(time_slope_list, 0.01),
+                        scipy.stats.mstats.trimmed_std(time_slope_list, 0.01),
+                    )
+                )
 
-        file_handler = gzip.open(output_file+"_time.template.gz", "wb")
+        file_handler = gzip.open(output_file + "_time.template.gz", "wb")
         pickle.dump(time_slope, file_handler)
         file_handler.close()
 
         fraction = {}
         for key in count.keys():
-            fraction[key] = (count[key]/total)
-        file_handler = gzip.open(output_file+"_fraction.template.gz", "wb")
+            fraction[key] = count[key] / total
+        file_handler = gzip.open(output_file + "_fraction.template.gz", "wb")
         pickle.dump(fraction, file_handler)
         file_handler.close()
 
         return True
 
     def calculate_correction_factors(self, pixel_x, pixel_y, amplitude, templates):
-        """ Funtion for performing a simple correction to the template amplitudes to
+        """Funtion for performing a simple correction to the template amplitudes to
         match the training images. Only needed if significant fit biases are seen
 
         :param file_list: list
             List of sim_telarray input files
         :param template_file: string
             File name of the template file
-        :param max_events: int  
+        :param max_events: int
             Maximum number of events to process
 
         :return: int
@@ -223,14 +240,14 @@ class NNFitter(Component):
         """
         from scipy.interpolate import RegularGridInterpolator
         from scipy.optimize import minimize
-        
+
         # Open up the template file
         keys = amplitude.keys()
 
         # Define our template binning
         x_bins = np.linspace(self.bounds[0][0], self.bounds[0][1], self.bins[0])
         y_bins = np.linspace(self.bounds[1][0], self.bounds[1][1], self.bins[1])
-        
+
         amp_vals = None
         pred_vals = None
 
@@ -242,12 +259,14 @@ class NNFitter(Component):
                 # And the event amplitudes and locations
                 amp, x, y = amplitude[key], pixel_x[key], pixel_y[key]
                 amp = np.array(amp)
-                
+
                 # Create interpolator for our template and predict amplitude
-                interpolator = RegularGridInterpolator((y_bins, x_bins), template, bounds_error=False, fill_value=0)
-                prediction = interpolator((y, x)) 
-                prediction[prediction<1e-6] = 1e-6
-                
+                interpolator = RegularGridInterpolator(
+                    (y_bins, x_bins), template, bounds_error=False, fill_value=0
+                )
+                prediction = interpolator((y, x))
+                prediction[prediction < 1e-6] = 1e-6
+
                 # Store the amplitude and prediction
                 if amp_vals is None:
                     amp_vals = amp
@@ -258,21 +277,25 @@ class NNFitter(Component):
 
             except KeyError:
                 True
-        
+
         # Define the Poissonian fit function used to fit datas
         def scale_like(scale_factor):
             # Reasonable values of single photoelection width and pedestal are used
             # Might need to change for different detector types
-            return np.sum(poisson_likelihood_gaussian(amp_vals, pred_vals*scale_factor[0], 0.5, 1))
+            return np.sum(
+                poisson_likelihood_gaussian(
+                    amp_vals, pred_vals * scale_factor[0], 0.5, 1
+                )
+            )
 
         if amp_vals is None:
             return 1
 
         # Minimise this function to get the scaling factor
-        res = minimize(scale_like, [1.], method='Nelder-Mead')
+        res = minimize(scale_like, [1.0], method="Nelder-Mead")
         # If our fit fails don't scale
         if res.x[0] is None:
             return 1
-        
+
         # Otherwise return scale factor
         return res.x[0]

--- a/template_builder/template_fitter.py
+++ b/template_builder/template_fitter.py
@@ -339,7 +339,7 @@ class TemplateFitter(Tool):
 
             # Get pixel coordinates and convert to the nominal system
             geom = self.event_source.subarray.tel[tel_id].camera.geometry
-            fl = self.event_source.subarray.tel[tel_id].optics.equivalent_focal_length
+            fl = geom.frame.focal_length.to(u.m)
 
             camera_coord = SkyCoord(
                 x=geom.pix_x,

--- a/template_builder/template_fitter.py
+++ b/template_builder/template_fitter.py
@@ -10,8 +10,11 @@ from astropy.coordinates import SkyCoord, AltAz
 import astropy.units as u
 import numpy as np
 
+from argparse import ArgumentParser
+from pathlib import Path
+
 from ctapipe.calib import CameraCalibrator, GainSelector
-from ctapipe.core import QualityQuery, Tool
+from ctapipe.core import QualityQuery, Tool, traits
 from ctapipe.core.traits import List, classes_with_traits, Unicode
 from ctapipe.image import ImageCleaner, ImageModifier, ImageProcessor
 from ctapipe.image.extractor import ImageExtractor
@@ -24,9 +27,9 @@ from ctapipe.io import (
     metadata,
 )
 from ctapipe.coordinates import (
-    CameraFrame, 
-    NominalFrame, 
-    GroundFrame, 
+    CameraFrame,
+    NominalFrame,
+    GroundFrame,
     TiltedGroundFrame,
 )
 
@@ -65,22 +68,41 @@ class TemplateFitter(Tool):
     example, see ctapipe/examples/stage1_config.json in the main code repo.
     """
 
-    input_files = Unicode(
-        default_value=".", help="list of input files"
+    input_dir = traits.Path(
+        default_value=None,
+        help="Input directory",
+        allow_none=True,
+        exists=True,
+        directory_ok=True,
+        file_ok=False,
     ).tag(config=True)
 
-    output_file = Unicode(
-        default_value=".", help="base output file name"
+    input_files = List(
+        traits.Path(exists=True, directory_ok=False),
+        default_value=[],
+        help="Input sim_telarray simulation files",
     ).tag(config=True)
+
+    file_pattern = Unicode(
+        default_value="*.simtel.zst",
+        help="Give a specific file pattern for matching files in ``input_dir``",
+    ).tag(config=True)
+
+    parser = ArgumentParser()
+    parser.add_argument("input_files", nargs="*", type=Path)
+
+    output_file = Unicode(default_value=".", help="base output file name").tag(
+        config=True
+    )
 
     xmax_bins = List(
-        default_value = np.linspace(-150, 200, 15).tolist(),
-        help = "bin centres for xmax bins",
+        default_value=np.linspace(-150, 200, 15).tolist(),
+        help="bin centres for xmax bins",
     ).tag(config=True)
 
     offset_bins = List(
-        default_value = [0.0],
-        help = "bin centres for offset bins (deg)",
+        default_value=[0.0],
+        help="bin centres for offset bins (deg)",
     ).tag(config=True)
 
     aliases = {
@@ -107,24 +129,38 @@ class TemplateFitter(Tool):
         + classes_with_traits(ImageModifier)
         + classes_with_traits(EventTypeFilter)
         + classes_with_traits(NNFitter)
-
     )
-
 
     def setup(self):
 
         # setup components:
-        self.input_file_list = self.input_files.split(",")
+        args = self.parser.parse_args(self.extra_args)
+        self.input_files.extend(args.input_files)
+        if self.input_dir is not None:
+            self.input_files.extend(sorted(self.input_dir.glob(self.file_pattern)))
 
-        self.focal_length_choice='EFFECTIVE'
+        if not self.input_files:
+            self.log.critical(
+                "No input files provided, either provide --input-dir "
+                "or input files as positional arguments"
+            )
+            sys.exit(1)
+
+        self.focal_length_choice = "EFFECTIVE"
         try:
-            self.event_source = EventSource(input_url=self.input_file_list[0], parent=self, 
-                    focal_length_choice=self.focal_length_choice)
+            self.event_source = EventSource(
+                input_url=self.input_files[0],
+                parent=self,
+                focal_length_choice=self.focal_length_choice,
+            )
         except RuntimeError:
             print("Effective Focal length not availible, defaulting to equivelent")
-            self.focal_length_choice='EQUIVALENT'
-            self.event_source = EventSource(input_url=self.input_file_list[0], parent=self, 
-                    focal_length_choice=self.focal_length_choice)
+            self.focal_length_choice = "EQUIVALENT"
+            self.event_source = EventSource(
+                input_url=self.input_files[0],
+                parent=self,
+                focal_length_choice=self.focal_length_choice,
+            )
 
         if not self.event_source.has_any_datalevel(COMPATIBLE_DATALEVELS):
             self.log.critical(
@@ -143,8 +179,8 @@ class TemplateFitter(Tool):
             subarray=self.event_source.subarray, parent=self
         )
         self.event_type_filter = EventTypeFilter(parent=self)
-        self.check_parameters = StereoQualityQuery(parent=self) 
-        
+        self.check_parameters = StereoQualityQuery(parent=self)
+
         # warn if max_events prevents writing the histograms
         if (
             isinstance(self.event_source, SimTelEventSource)
@@ -157,15 +193,15 @@ class TemplateFitter(Tool):
                 "shower distributions read from the input Simulation file are invalid)."
             )
 
-        self.fitter = NNFitter()
+        self.fitter = NNFitter(parent=self)
 
         # We need this dummy time for coord conversions later
-        self.dummy_time = Time('2010-01-01T00:00:00', format='isot', scale='utc')
+        self.dummy_time = Time("2010-01-01T00:00:00", format="isot", scale="utc")
         self.point, self.xmax_scale, self.tilt_tel = None, None, None
 
         self.time_slope, self.templates = {}, {}  # Pixel amplitude
-        self.templates_xb, self.templates_yb = {}, {} # Rotated Y positions
-        self.count = {} # Count of events in a given template
+        self.templates_xb, self.templates_yb = {}, {}  # Rotated Y positions
+        self.count = {}  # Count of events in a given template
         self.count_total = 0
 
     def start(self):
@@ -175,37 +211,48 @@ class TemplateFitter(Tool):
 
         self.event_source.subarray.info(printer=self.log.info)
 
-        for input_file in self.input_file_list:
-            self.event_source = EventSource(input_url=input_file, parent=self, 
-                focal_length_choice=self.focal_length_choice)
+        for input_file in self.input_files:
+            self.event_source = EventSource(
+                input_url=input_file,
+                parent=self,
+                focal_length_choice=self.focal_length_choice,
+            )
             self.point, self.xmax_scale, self.tilt_tel = None, None, None
 
             for event in tqdm(
                 self.event_source,
                 desc=self.event_source.__class__.__name__,
                 total=self.event_source.max_events,
-                unit="events"
-                ):
+                unit="events",
+            ):
 
                 self.log.debug("Processessing event_id=%s", event.index.event_id)
                 self.calibrate(event)
                 self.process_images(event)
 
                 self.read_template(event)
-            
+
             # Not sure what else to do here...
             obs_ids = self.event_source.simulation_config.keys()
             for obs_id in obs_ids:
-                self.count_total += self.event_source.simulation_config[obs_id].n_showers
+                self.count_total += self.event_source.simulation_config[
+                    obs_id
+                ].n_showers
             self.event_source.close()
 
     def finish(self):
         """
         Last steps after processing events.
         """
-        self.fitter.generate_templates(self.templates_xb, self.templates_yb, self.templates,
-                                    self.time_slope, self.count, self.count_total, 
-                                    output_file=self.output_file)
+        self.fitter.generate_templates(
+            self.templates_xb,
+            self.templates_yb,
+            self.templates,
+            self.time_slope,
+            self.count,
+            self.count_total,
+            output_file=self.output_file,
+        )
 
     def read_template(self, event):
         """_summary_
@@ -218,49 +265,69 @@ class TemplateFitter(Tool):
         # above 90 deg
         alt_evt = event.simulation.shower.alt
         if alt_evt > 90 * u.deg:
-            alt_evt = 90*u.deg
+            alt_evt = 90 * u.deg
 
         # Get the pointing direction and telescope positions of this run
         if self.point is None:
             alt = event.pointing.array_altitude
             if alt > 90 * u.deg:
-                alt = 90*u.deg
+                alt = 90 * u.deg
 
-            self.point = SkyCoord(alt=alt, az=event.pointing.array_azimuth,
-                    frame=AltAz(obstime=self.dummy_time))
-            self.xmax_scale = create_xmax_scaling(self.xmax_bins, np.array(self.offset_bins)*u.deg, \
-                    self.point, self.event_source.input_url)
+            self.point = SkyCoord(
+                alt=alt,
+                az=event.pointing.array_azimuth,
+                frame=AltAz(obstime=self.dummy_time),
+            )
+            self.xmax_scale = create_xmax_scaling(
+                self.xmax_bins,
+                np.array(self.offset_bins) * u.deg,
+                self.point,
+                self.event_source.input_url,
+            )
 
             grd_tel = self.event_source.subarray.tel_coords
             # Convert to tilted system
             self.tilt_tel = grd_tel.transform_to(
-                TiltedGroundFrame(pointing_direction=self.point))
+                TiltedGroundFrame(pointing_direction=self.point)
+            )
 
         # Create coordinate objects for source position
-        src = SkyCoord(alt=event.simulation.shower.alt.value * u.rad, 
-                        az=event.simulation.shower.az.value * u.rad,
-                        frame=AltAz(obstime=self.dummy_time))
+        src = SkyCoord(
+            alt=event.simulation.shower.alt.value * u.rad,
+            az=event.simulation.shower.az.value * u.rad,
+            frame=AltAz(obstime=self.dummy_time),
+        )
 
-
-        offset_bin = find_nearest_bin(np.array(self.offset_bins)*u.deg, self.point.separation(src)).value
+        offset_bin = find_nearest_bin(
+            np.array(self.offset_bins) * u.deg, self.point.separation(src)
+        ).value
 
         zen = 90 - event.simulation.shower.alt.to(u.deg).value
         # Store simulated Xmax
         mc_xmax = event.simulation.shower.x_max.value / np.cos(np.deg2rad(zen))
 
-        # And transform into nominal system (where we store our templates)
-        source_direction = src.transform_to(NominalFrame(origin=self.point))
-
         # Store simulated event energy
         energy = event.simulation.shower.energy
 
-        # Calculate core position in tilted system
-        grd_core_true = SkyCoord(x=np.asarray(event.simulation.shower.core_x) * u.m,
-                                    y=np.asarray(event.simulation.shower.core_y) * u.m,
-                                    z=np.asarray(0) * u.m, frame=GroundFrame())
+        # Calc difference from expected Xmax (for gammas)
+        exp_xmax = xmax_expectation(energy.value)
+        x_diff = mc_xmax - exp_xmax
+        x_diff_bin = find_nearest_bin(self.xmax_bins, x_diff)
 
-        tilt_core_true = grd_core_true.transform_to(TiltedGroundFrame(
-            pointing_direction=self.point))
+        # And transform into nominal system (where we store our templates)
+        source_direction = src.transform_to(NominalFrame(origin=self.point))
+
+        # Calculate core position in tilted system
+        grd_core_true = SkyCoord(
+            x=np.asarray(event.simulation.shower.core_x) * u.m,
+            y=np.asarray(event.simulation.shower.core_y) * u.m,
+            z=np.asarray(0) * u.m,
+            frame=GroundFrame(),
+        )
+
+        tilt_core_true = grd_core_true.transform_to(
+            TiltedGroundFrame(pointing_direction=self.point)
+        )
 
         # Loop over triggered telescopes
         for tel_id, dl1 in event.dl1.tel.items():
@@ -274,36 +341,44 @@ class TemplateFitter(Tool):
             geom = self.event_source.subarray.tel[tel_id].camera.geometry
             fl = self.event_source.subarray.tel[tel_id].optics.equivalent_focal_length
 
-            camera_coord = SkyCoord(x=geom.pix_x, y=geom.pix_y,
-                                    frame=CameraFrame(focal_length=fl,
-                                                        telescope_pointing=self.point))
+            camera_coord = SkyCoord(
+                x=geom.pix_x,
+                y=geom.pix_y,
+                frame=CameraFrame(focal_length=fl, telescope_pointing=self.point),
+            )
 
-            nom_coord = camera_coord.transform_to(
-                NominalFrame(origin=self.point))
+            nom_coord = camera_coord.transform_to(NominalFrame(origin=self.point))
 
             x = nom_coord.fov_lon.to(u.deg)
             y = nom_coord.fov_lat.to(u.deg)
 
             # Calculate expected rotation angle of the image
-            phi = np.arctan2((self.tilt_tel.y[tel_id - 1] - tilt_core_true.y),
-                                (self.tilt_tel.x[tel_id - 1] - tilt_core_true.x)) + \
-                    90 * u.deg
-
+            phi = (
+                np.arctan2(
+                    (self.tilt_tel.y[tel_id - 1] - tilt_core_true.y),
+                    (self.tilt_tel.x[tel_id - 1] - tilt_core_true.x),
+                )
+                + 90 * u.deg
+            )
             # And the impact distance of the shower
-            impact = np.sqrt(np.power(self.tilt_tel.x[tel_id - 1] - tilt_core_true.x, 2) +
-                                np.power(self.tilt_tel.y[tel_id - 1] - tilt_core_true.y, 2)). \
-                to(u.m).value
-            
+            impact = (
+                np.sqrt(
+                    np.power(self.tilt_tel.x[tel_id - 1] - tilt_core_true.x, 2)
+                    + np.power(self.tilt_tel.y[tel_id - 1] - tilt_core_true.y, 2)
+                )
+                .to(u.m)
+                .value
+            )
+
             mask = event.dl1.tel[tel_id].image_mask
             # now rotate and translate our images such that they lie on top of one
             # another
-            x, y = rotate_translate(x, y,
-                                    source_direction.fov_lon,
-                                    source_direction.fov_lat,
-                                    phi)
-            x *= -1 # Reverse x axis to fit HESS convention
+            x, y = rotate_translate(
+                x, y, source_direction.fov_lon, source_direction.fov_lat, phi
+            )
+            x *= -1  # Reverse x axis to fit HESS convention
             x, y = x.ravel(), y.ravel()
-    
+
             for i in range(4):
                 mask = dilate(geom, mask)
 
@@ -313,43 +388,42 @@ class TemplateFitter(Tool):
             image = pmt_signal[mask].astype(np.float32)
             time_slope = dl1.parameters.timing.slope.value
 
-            # Store simulated Xmax
-            mc_xmax = event.simulation.shower.x_max.value / np.cos(np.deg2rad(zen))
+            pt_az = self.point.az.to(u.deg).value
+            pt_zen = 90.0 - self.point.alt.to(u.deg).value
 
-            # Calc difference from expected Xmax (for gammas)
-            exp_xmax = xmax_expectation(energy.value)
-            x_diff = mc_xmax - exp_xmax
-            x_diff_bin = find_nearest_bin(self.xmax_bins, x_diff)
-
-            az = self.point.az.to(u.deg).value
-            zen = 90. - self.point.alt.to(u.deg).value
-            
             # Now fill up our output with the X, Y and amplitude of our pixels
-            key = zen, az, energy.value, int(impact), x_diff_bin, offset_bin
+            key = pt_zen, pt_az, energy.value, int(impact), x_diff_bin, offset_bin
 
             if (key) in self.templates.keys():
                 # Extend the list if an entry already exists
                 self.templates[key].extend(image)
                 self.templates_xb[key].extend(x.value.tolist())
                 self.templates_yb[key].extend(y.value.tolist())
-                self.count[key] = self.count[key] + (1  * self.xmax_scale[(x_diff_bin, offset_bin)])
+                self.count[key] = self.count[key] + (
+                    1 * self.xmax_scale[(x_diff_bin, offset_bin)]
+                )
                 self.time_slope[key].append(time_slope)
             else:
                 self.templates[key] = image.tolist()
-                self.templates_xb[key] = x.value.tolist()#.value#.tolist()
-                self.templates_yb[key] = y.value.tolist()#.value#.tolist()
+                self.templates_xb[key] = x.value.tolist()  # .value#.tolist()
+                self.templates_yb[key] = y.value.tolist()  # .value#.tolist()
                 self.count[key] = 1 * self.xmax_scale[(x_diff_bin, offset_bin)]
                 self.time_slope[key] = [time_slope]
 
 
 def main():
     """run the tool"""
-    print("=======================================================================================")
+    print(
+        "======================================================================================="
+    )
     tprint("Template   Fitter")
-    print("=======================================================================================")
+    print(
+        "======================================================================================="
+    )
 
     tool = TemplateFitter()
     tool.run()
+
 
 if __name__ == "__main__":
     main()

--- a/template_builder/utilities.py
+++ b/template_builder/utilities.py
@@ -5,8 +5,15 @@ from eventio.simtel import MCShower
 from astropy.coordinates import SkyCoord, AltAz
 from astropy.time import Time
 
-__all__ = ["find_nearest_bin", "create_angular_area_scaling", "poisson_likelihood_gaussian",
-           "tensor_poisson_likelihood", "create_xmax_scaling", "xmax_expectation", "rotate_translate"]
+__all__ = [
+    "find_nearest_bin",
+    "create_angular_area_scaling",
+    "poisson_likelihood_gaussian",
+    "tensor_poisson_likelihood",
+    "create_xmax_scaling",
+    "xmax_expectation",
+    "rotate_translate",
+]
 
 
 def find_nearest_bin(array, value):
@@ -23,6 +30,7 @@ def find_nearest_bin(array, value):
 
     idx = (np.abs(array - value)).argmin()
     return array[idx]
+
 
 def rotate_translate(pixel_pos_x, pixel_pos_y, x_trans, y_trans, phi):
     """
@@ -54,11 +62,13 @@ def rotate_translate(pixel_pos_x, pixel_pos_y, x_trans, y_trans, phi):
     pixel_pos_trans_y = (pixel_pos_x - x_trans) * sin_angle + (
         pixel_pos_y - y_trans
     ) * cosine_angle
-    
+
     return pixel_pos_trans_x, pixel_pos_trans_y
+
 
 def xmax_expectation(energy):
     return 300 + 93 * np.log10(energy)
+
 
 def create_angular_area_scaling(offset_bins, max_viewcone_radius):
     # Argh this code is horrible, but need to account for the angular area contained in each offset bin
@@ -67,23 +77,25 @@ def create_angular_area_scaling(offset_bins, max_viewcone_radius):
     if len(offset_bins) == 1:
         offset_area_scale[offset_bins[0].value] = 1
     else:
+
         def angular_area(rmin, rmax):
-            return np.pi * rmax**2 - np.pi*rmin**2
-        total_area = angular_area(0*u.deg, max_viewcone_radius)             
-        
-        i=0
-        imax=offset_bins.shape[0]-1
-        diff = np.diff(offset_bins)/2
+            return np.pi * rmax**2 - np.pi * rmin**2
+
+        total_area = angular_area(0 * u.deg, max_viewcone_radius)
+
+        i = 0
+        imax = offset_bins.shape[0] - 1
+        diff = np.diff(offset_bins) / 2
 
         for offset in offset_bins:
 
             upper_bound = offset + diff
-            if i<imax:
+            if i < imax:
                 upper_bound = offset + diff
             lower_bound = 0
-            if i>0:
-                lower_bound = offset-diff
-            
+            if i > 0:
+                lower_bound = offset - diff
+
             print(upper_bound, lower_bound)
             ring_area = angular_area(lower_bound, upper_bound)
 
@@ -91,32 +103,35 @@ def create_angular_area_scaling(offset_bins, max_viewcone_radius):
             i += 1
     return offset_area_scale
 
+
 def create_xmax_scaling(xmax_bins, offset_bins, array_pointing, filename):
     output_dict = {}
     shower_count = 0
 
     with EventIOFile(filename) as f:
 
-        dummy_time = Time('2010-01-01T00:00:00', format='isot', scale='utc')
+        dummy_time = Time("2010-01-01T00:00:00", format="isot", scale="utc")
 
         for o in f:
             if isinstance(o, MCShower):
 
                 mc_shower = o.parse()
-                
+
                 energy = mc_shower["energy"]
                 xmax_exp = xmax_expectation(energy)
-                zenith = (np.pi/2) - mc_shower['altitude']
+                zenith = (np.pi / 2) - mc_shower["altitude"]
 
                 xmax = mc_shower["xmax"] / np.cos(zenith)
-                xmax_bin = find_nearest_bin(xmax_bins, xmax-xmax_exp)
+                xmax_bin = find_nearest_bin(xmax_bins, xmax - xmax_exp)
 
-                shower_direction = SkyCoord(alt=mc_shower['altitude']*u.rad, 
-                                            az=mc_shower['azimuth']*u.rad, 
-                                            frame=AltAz(obstime=dummy_time))
+                shower_direction = SkyCoord(
+                    alt=mc_shower["altitude"] * u.rad,
+                    az=mc_shower["azimuth"] * u.rad,
+                    frame=AltAz(obstime=dummy_time),
+                )
                 offset = array_pointing.separation(shower_direction).to(u.deg).value
                 offset_bin = find_nearest_bin(offset_bins.value, offset)
-#                print(offset, offset_bin, xmax, xmax_exp, xmax-xmax_exp, xmax_bin, np.rad2deg(zenith))
+                #                print(offset, offset_bin, xmax, xmax_exp, xmax-xmax_exp, xmax_bin, np.rad2deg(zenith))
                 key = xmax_bin, offset_bin
                 if key in output_dict.keys():
                     output_dict[key] += 1
@@ -125,9 +140,10 @@ def create_xmax_scaling(xmax_bins, offset_bins, array_pointing, filename):
                 shower_count += 1
 
     for key in output_dict.keys():
-        output_dict[key] = float(shower_count)/output_dict[key]
+        output_dict[key] = float(shower_count) / output_dict[key]
 
-    return output_dict 
+    return output_dict
+
 
 def poisson_likelihood_gaussian(image, prediction, spe_width=0.5, ped=1):
 
@@ -135,19 +151,21 @@ def poisson_likelihood_gaussian(image, prediction, spe_width=0.5, ped=1):
     prediction = np.asarray(prediction)
     spe_width = np.asarray(spe_width)
     ped = np.asarray(ped)
-    
-    sq = 1. / np.sqrt(2 * np.pi * (np.power(ped, 2)
-                                + prediction * (1 + np.power(spe_width, 2))))
-    
-    diff = np.power(image - prediction, 2.)
+
+    sq = 1.0 / np.sqrt(
+        2 * np.pi * (np.power(ped, 2) + prediction * (1 + np.power(spe_width, 2)))
+    )
+
+    diff = np.power(image - prediction, 2.0)
     denom = 2 * (np.power(ped, 2) + prediction * (1 + np.power(spe_width, 2)))
     expo = np.asarray(np.exp(-1 * diff / denom))
-    
+
     # If we are outside of the range of datatype, fix to lower bound
     min_prob = np.finfo(expo.dtype).tiny
     expo[expo < min_prob] = min_prob
-    
+
     return -2 * np.log(sq * expo)
+
 
 def tensor_poisson_likelihood(image, prediction, spe_width=0.5, ped=1):
     import keras.backend as K
@@ -155,11 +173,12 @@ def tensor_poisson_likelihood(image, prediction, spe_width=0.5, ped=1):
 
     prediction = tf.clip_by_value(prediction, 1e-6, 1e9)
 
-    sq = 1. / K.sqrt(2. * np.pi * (K.square(ped)
-                                + prediction * (1. + K.square(spe_width))))
+    sq = 1.0 / K.sqrt(
+        2.0 * np.pi * (K.square(ped) + prediction * (1.0 + K.square(spe_width)))
+    )
 
     diff = K.square(image - prediction)
-    denom = 2. * (K.square(ped) + prediction * (1 + K.square(spe_width)))
+    denom = 2.0 * (K.square(ped) + prediction * (1 + K.square(spe_width)))
     expo = K.exp(-1 * diff / denom)
     expo = tf.clip_by_value(expo, 1e-20, 100)
 


### PR DESCRIPTION
This includes a couple of fixes that I needed to create working templates and a tool to merge subdictionaries into one large template dictionary.

The fixes are:
- The output of `nn_fitter.perform_fit()` is transposed
- The xmax bin is now chosen exclusively considering the proper event zenith, not the pointing zenith. This is consistent with how the dictionary in `utilities.create_xmax_scaling() `is created. Otherwise, an error can occur when a diffuse source is simulated and an event by chance is assigned to a different xmax bin because of the difference between event zenith and pointing zenith.  
- You can now give a directory to the `template-fitter` tool and specify that e.g. all files ending in `*simtel.zst` in that directory should be considered. This is just for convenience. 

The `merge-templates` is to simplify the workflow where sub-templates are generated in parallel and then later merged into one. This tool does the merging automatically.