### PR TITLE
Create time gradient templates with sign & Compute template types separately

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ channels:
   - conda-forge
 dependencies:
   - astropy
-  - ctapipe==0.19
+  - ctapipe==0.19.3
   - ipython
   - jupyter
   - matplotlib

--- a/template_builder/nn_fitter.py
+++ b/template_builder/nn_fitter.py
@@ -21,7 +21,6 @@ from tqdm import tqdm
 
 
 class NNFitter(Component):
-
     bounds = List(
         default_value=[[-5, 1], [-1.5, 1.5]],
         help="X and Y boundaries of template",
@@ -64,7 +63,6 @@ class NNFitter(Component):
 
         # Loop over all templates
         for key in tqdm(list(amplitude.keys())):
-
             amp = np.array(amplitude[key])
             # Skip if we do not have enough image pixels
             if len(amp) < self.min_fit_pixels:
@@ -167,9 +165,7 @@ class NNFitter(Component):
 
         return model_pred.reshape((self.bins[1], self.bins[0])).T
 
-    def generate_templates(
-        self, x, y, amplitude, time, count, total, output_file="./Template"
-    ):
+    def generate_image_templates(self, x, y, amplitude, output_file="./Template"):
         """
 
         :param file_list: list
@@ -198,28 +194,6 @@ class NNFitter(Component):
             templates[t] = templates[t] * correction_factor
         file_handler = gzip.open(output_file + "_corrected.template.gz", "wb")
         pickle.dump(templates, file_handler)
-        file_handler.close()
-
-        time_slope = {}
-        for key in tqdm(list(time.keys())):
-            time_slope_list = time[key]
-            if len(time_slope_list) > 5:
-                time_slope[key] = np.array(
-                    (
-                        scipy.stats.trim_mean(time_slope_list, 0.01),
-                        scipy.stats.mstats.trimmed_std(time_slope_list, 0.01),
-                    )
-                )
-
-        file_handler = gzip.open(output_file + "_time.template.gz", "wb")
-        pickle.dump(time_slope, file_handler)
-        file_handler.close()
-
-        fraction = {}
-        for key in count.keys():
-            fraction[key] = count[key] / total
-        file_handler = gzip.open(output_file + "_fraction.template.gz", "wb")
-        pickle.dump(fraction, file_handler)
         file_handler.close()
 
         return True

--- a/template_builder/template_fitter.py
+++ b/template_builder/template_fitter.py
@@ -5,17 +5,21 @@ Generate DL1 (a or b) output files in HDF5 format from {R0,R1,DL0} inputs.
 from email.policy import default
 import sys
 
+import gzip
+import pickle
+
 from tqdm.auto import tqdm
 from astropy.coordinates import SkyCoord, AltAz
 import astropy.units as u
 import numpy as np
+import scipy
 
 from argparse import ArgumentParser
 from pathlib import Path
 
 from ctapipe.calib import CameraCalibrator, GainSelector
 from ctapipe.core import QualityQuery, Tool, traits
-from ctapipe.core.traits import List, classes_with_traits, Unicode
+from ctapipe.core.traits import List, classes_with_traits, Unicode, Bool
 from ctapipe.image import ImageCleaner, ImageModifier, ImageProcessor
 from ctapipe.image.extractor import ImageExtractor
 from ctapipe.reco.reconstructor import StereoQualityQuery
@@ -113,6 +117,26 @@ class TemplateFitter(Tool):
         "image-cleaner-type": "ImageProcessor.image_cleaner_type",
     }
 
+    compute_all = Bool(
+        help="Compute all possible templates",
+        default_value=False,
+    ).tag(config=True)
+
+    compute_image = Bool(
+        help="Compute image templates",
+        default_value=False,
+    ).tag(config=True)
+
+    compute_time = Bool(
+        help="Compute time templates",
+        default_value=False,
+    ).tag(config=True)
+
+    compute_fraction = Bool(
+        help="Compute fraction templates",
+        default_value=False,
+    ).tag(config=True)
+
     classes = (
         [
             CameraCalibrator,
@@ -132,7 +156,6 @@ class TemplateFitter(Tool):
     )
 
     def setup(self):
-
         # setup components:
         args = self.parser.parse_args(self.extra_args)
         self.input_files.extend(args.input_files)
@@ -193,16 +216,46 @@ class TemplateFitter(Tool):
                 "shower distributions read from the input Simulation file are invalid)."
             )
 
-        self.fitter = NNFitter(parent=self)
+        if self.compute_all or self.compute_image:
+            self.image_computation = True
+        else:
+            self.image_computation = False
+        if self.compute_all or self.compute_time:
+            self.time_computation = True
+        else:
+            self.time_computation = False
+        if self.compute_all or self.compute_fraction:
+            self.fraction_computation = True
+        else:
+            self.fraction_computation = False
+        if (
+            not self.compute_all
+            and not self.compute_image
+            and not self.compute_time
+            and not self.compute_fraction
+        ):
+            self.fraction_computation = True
+            self.time_computation = True
+            self.image_computation = True
 
         # We need this dummy time for coord conversions later
         self.dummy_time = Time("2010-01-01T00:00:00", format="isot", scale="utc")
-        self.point, self.xmax_scale, self.tilt_tel = None, None, None
+        # self.point, self.xmax_scale, self.tilt_tel = None, None, None
 
-        self.time_slope, self.templates = {}, {}  # Pixel amplitude
-        self.templates_xb, self.templates_yb = {}, {}  # Rotated Y positions
-        self.count = {}  # Count of events in a given template
-        self.count_total = 0
+        if self.time_computation:
+            self.time_slope = {}  # Image time gradients
+        if self.image_computation:
+            self.templates, self.templates_xb, self.templates_yb = (
+                {},
+                {},
+                {},
+            )  # Pixel amplitudes and rotated positions
+            self.fitter = NNFitter(parent=self)
+        if self.fraction_computation:
+            self.count = {}  # Count of events in a given template
+            self.count_total = 0
+
+        self.key_list = []
 
     def start(self):
         """
@@ -225,7 +278,6 @@ class TemplateFitter(Tool):
                 total=self.event_source.max_events,
                 unit="events",
             ):
-
                 self.log.debug("Processessing event_id=%s", event.index.event_id)
                 self.calibrate(event)
                 self.process_images(event)
@@ -233,26 +285,29 @@ class TemplateFitter(Tool):
                 self.read_template(event)
 
             # Not sure what else to do here...
-            obs_ids = self.event_source.simulation_config.keys()
-            for obs_id in obs_ids:
-                self.count_total += self.event_source.simulation_config[
-                    obs_id
-                ].n_showers
+            if self.fraction_computation:
+                obs_ids = self.event_source.simulation_config.keys()
+                for obs_id in obs_ids:
+                    self.count_total += self.event_source.simulation_config[
+                        obs_id
+                    ].n_showers
             self.event_source.close()
 
     def finish(self):
         """
         Last steps after processing events.
         """
-        self.fitter.generate_templates(
-            self.templates_xb,
-            self.templates_yb,
-            self.templates,
-            self.time_slope,
-            self.count,
-            self.count_total,
-            output_file=self.output_file,
-        )
+        if self.image_computation:
+            self.fitter.generate_image_templates(
+                self.templates_xb,
+                self.templates_yb,
+                self.templates,
+                output_file=self.output_file,
+            )
+        if self.time_computation:
+            self.generate_time_templates()
+        if self.fraction_computation:
+            self.generate_fraction_templates()
 
     def read_template(self, event):
         """_summary_
@@ -278,12 +333,14 @@ class TemplateFitter(Tool):
                 az=event.pointing.array_azimuth,
                 frame=AltAz(obstime=self.dummy_time),
             )
-            self.xmax_scale = create_xmax_scaling(
-                self.xmax_bins,
-                np.array(self.offset_bins) * u.deg,
-                self.point,
-                self.event_source.input_url,
-            )
+
+            if self.fraction_computation:
+                self.xmax_scale = create_xmax_scaling(
+                    self.xmax_bins,
+                    np.array(self.offset_bins) * u.deg,
+                    self.point,
+                    self.event_source.input_url,
+                )
 
             grd_tel = self.event_source.subarray.tel_coords
             # Convert to tilted system
@@ -291,31 +348,35 @@ class TemplateFitter(Tool):
                 TiltedGroundFrame(pointing_direction=self.point)
             )
 
+        # These values are keys for the template dict later
+        pt_az = self.point.az.to(u.deg).value
+        pt_zen = 90.0 - self.point.alt.to(u.deg).value
+
         # Create coordinate objects for source position
         src = SkyCoord(
             alt=event.simulation.shower.alt.value * u.rad,
             az=event.simulation.shower.az.value * u.rad,
             frame=AltAz(obstime=self.dummy_time),
         )
-
+        # Next key for template dict: Offset
         offset_bin = find_nearest_bin(
             np.array(self.offset_bins) * u.deg, self.point.separation(src)
         ).value
 
+        # Store simulated event energy. A key for the template dict.
+        energy = event.simulation.shower.energy
+
+        # Calcualtion of xmax bin as a key for the template dicts later
         zen = 90 - event.simulation.shower.alt.to(u.deg).value
         # Store simulated Xmax
         mc_xmax = event.simulation.shower.x_max.value / np.cos(np.deg2rad(zen))
 
-        # Store simulated event energy
-        energy = event.simulation.shower.energy
-
-        # Calc difference from expected Xmax (for gammas)
+        # Calc difference from expected Xmax (for gammas).
         exp_xmax = xmax_expectation(energy.value)
         x_diff = mc_xmax - exp_xmax
         x_diff_bin = find_nearest_bin(self.xmax_bins, x_diff)
 
-        # And transform into nominal system (where we store our templates)
-        source_direction = src.transform_to(NominalFrame(origin=self.point))
+        # Finally, set up some properties that are needed in the per-telescope calculations
 
         # Calculate core position in tilted system
         grd_core_true = SkyCoord(
@@ -325,90 +386,140 @@ class TemplateFitter(Tool):
             frame=GroundFrame(),
         )
 
-        tilt_core_true = grd_core_true.transform_to(
+        self.tilt_core_true = grd_core_true.transform_to(
             TiltedGroundFrame(pointing_direction=self.point)
         )
 
-        # Loop over triggered telescopes
+        # transform source direction into nominal system (where we store our templates)
+        self.source_direction = src.transform_to(NominalFrame(origin=self.point))
+
+        # Loop over triggered telescopes. Everything beyond here is depends on telescope
         for tel_id, dl1 in event.dl1.tel.items():
             #  Get pixel signal
             if np.all(self.check_parameters(parameters=dl1.parameters)) is False:
                 continue
 
-            pmt_signal = dl1.image
-
-            # Get pixel coordinates and convert to the nominal system
-            geom = self.event_source.subarray.tel[tel_id].camera.geometry
-            fl = geom.frame.focal_length.to(u.m)
-
-            camera_coord = SkyCoord(
-                x=geom.pix_x,
-                y=geom.pix_y,
-                frame=CameraFrame(focal_length=fl, telescope_pointing=self.point),
-            )
-
-            nom_coord = camera_coord.transform_to(NominalFrame(origin=self.point))
-
-            x = nom_coord.fov_lon.to(u.deg)
-            y = nom_coord.fov_lat.to(u.deg)
-
-            # Calculate expected rotation angle of the image
-            phi = (
-                np.arctan2(
-                    (self.tilt_tel.y[tel_id - 1] - tilt_core_true.y),
-                    (self.tilt_tel.x[tel_id - 1] - tilt_core_true.x),
-                )
-                + 90 * u.deg
-            )
-            # And the impact distance of the shower
+            # First set the the last dict key missing, the impact distance
             impact = (
                 np.sqrt(
-                    np.power(self.tilt_tel.x[tel_id - 1] - tilt_core_true.x, 2)
-                    + np.power(self.tilt_tel.y[tel_id - 1] - tilt_core_true.y, 2)
+                    np.power(self.tilt_tel.x[tel_id - 1] - self.tilt_core_true.x, 2)
+                    + np.power(self.tilt_tel.y[tel_id - 1] - self.tilt_core_true.y, 2)
                 )
                 .to(u.m)
                 .value
             )
 
-            mask = event.dl1.tel[tel_id].image_mask
-            # now rotate and translate our images such that they lie on top of one
-            # another
-            x, y = rotate_translate(
-                x, y, source_direction.fov_lon, source_direction.fov_lat, phi
-            )
-            x *= -1  # Reverse x axis to fit HESS convention
-            x, y = x.ravel(), y.ravel()
+            if self.image_computation:
+                x, y, image = self.make_image_prediction(tel_id, dl1)
 
-            for i in range(4):
-                mask = dilate(geom, mask)
-
-            # Make sure everything is 32 bit
-            x = x[mask].astype(np.float32)
-            y = y[mask].astype(np.float32)
-            image = pmt_signal[mask].astype(np.float32)
-            time_slope = dl1.parameters.timing.slope.value
-
-            pt_az = self.point.az.to(u.deg).value
-            pt_zen = 90.0 - self.point.alt.to(u.deg).value
+            if self.time_computation:
+                time_slope = np.abs(dl1.parameters.timing.slope.value)
 
             # Now fill up our output with the X, Y and amplitude of our pixels
             key = pt_zen, pt_az, energy.value, int(impact), x_diff_bin, offset_bin
 
-            if (key) in self.templates.keys():
+            if (key) in self.key_list:
                 # Extend the list if an entry already exists
-                self.templates[key].extend(image)
-                self.templates_xb[key].extend(x.value.tolist())
-                self.templates_yb[key].extend(y.value.tolist())
-                self.count[key] = self.count[key] + (
-                    1 * self.xmax_scale[(x_diff_bin, offset_bin)]
-                )
-                self.time_slope[key].append(time_slope)
+                if self.image_computation:
+                    self.templates[key].extend(image)
+                    self.templates_xb[key].extend(x.value.tolist())
+                    self.templates_yb[key].extend(y.value.tolist())
+                if self.fraction_computation:
+                    self.count[key] = self.count[key] + (
+                        1 * self.xmax_scale[(x_diff_bin, offset_bin)]
+                    )
+                if self.time_computation:
+                    self.time_slope[key].append(time_slope)
             else:
-                self.templates[key] = image.tolist()
-                self.templates_xb[key] = x.value.tolist()  # .value#.tolist()
-                self.templates_yb[key] = y.value.tolist()  # .value#.tolist()
-                self.count[key] = 1 * self.xmax_scale[(x_diff_bin, offset_bin)]
-                self.time_slope[key] = [time_slope]
+                self.key_list.append((key))
+                if self.image_computation:
+                    self.templates[key] = image.tolist()
+                    self.templates_xb[key] = x.value.tolist()  # .value#.tolist()
+                    self.templates_yb[key] = y.value.tolist()  # .value#.tolist()
+                if self.fraction_computation:
+                    self.count[key] = 1 * self.xmax_scale[(x_diff_bin, offset_bin)]
+                if self.time_computation:
+                    self.time_slope[key] = [time_slope]
+
+    def make_image_prediction(self, tel_id, dl1):
+        """
+        Compute rotated pixel positions and image amplitudes for a given telescope
+
+        Returns
+        -------
+        x,y: Rotated pixel coordinates in deg
+        iamge: Pixel amplitudes
+        """
+
+        pmt_signal = dl1.image
+
+        # Get pixel coordinates and convert to the nominal system
+        geom = self.event_source.subarray.tel[tel_id].camera.geometry
+        fl = geom.frame.focal_length.to(u.m)
+
+        camera_coord = SkyCoord(
+            x=geom.pix_x,
+            y=geom.pix_y,
+            frame=CameraFrame(focal_length=fl, telescope_pointing=self.point),
+        )
+
+        nom_coord = camera_coord.transform_to(NominalFrame(origin=self.point))
+
+        x = nom_coord.fov_lon.to(u.deg)
+        y = nom_coord.fov_lat.to(u.deg)
+
+        # Calculate expected rotation angle of the image
+        phi = (
+            np.arctan2(
+                (self.tilt_tel.y[tel_id - 1] - self.tilt_core_true.y),
+                (self.tilt_tel.x[tel_id - 1] - self.tilt_core_true.x),
+            )
+            + 90 * u.deg
+        )
+
+        mask = dl1.image_mask
+        # now rotate and translate our images such that they lie on top of one
+        # another
+        x, y = rotate_translate(
+            x, y, self.source_direction.fov_lon, self.source_direction.fov_lat, phi
+        )
+        x *= -1  # Reverse x axis to fit HESS convention
+        x, y = x.ravel(), y.ravel()
+
+        for i in range(4):
+            mask = dilate(geom, mask)
+
+        # Make sure everything is 32 bit
+        x = x[mask].astype(np.float32)
+        y = y[mask].astype(np.float32)
+        image = pmt_signal[mask].astype(np.float32)
+
+        return x, y, image
+
+    def generate_time_templates(self):
+        time_slope_template = {}
+        for key in tqdm(list(self.time_slope.keys())):
+            time_slope_list = np.asarray(self.time_slope[key])
+            time_slope_list = time_slope_list[~np.isnan(time_slope_list)]
+            if len(time_slope_list) > 5:
+                time_slope_template[key] = np.array(
+                    (
+                        scipy.stats.trim_mean(time_slope_list, 0.01),
+                        scipy.stats.mstats.trimmed_std(time_slope_list, 0.01),
+                    )
+                )
+
+        file_handler = gzip.open(self.output_file + "_time.template.gz", "wb")
+        pickle.dump(time_slope_template, file_handler)
+        file_handler.close()
+
+    def generate_fraction_templates(self):
+        fraction = {}
+        for key in self.count.keys():
+            fraction[key] = self.count[key] / self.count_total
+        file_handler = gzip.open(self.output_file + "_fraction.template.gz", "wb")
+        pickle.dump(fraction, file_handler)
+        file_handler.close()
 
 
 def main():


### PR DESCRIPTION
There are two main changes in this pull request:

Time gradients are now calculated explicitly with the true source position in the center, instead of using the timing_slope dl1 parameter that has the brightest pixel in the center. This leads to a consistent sign of the slope between events and allows one to see the sign flip for nearby events. 

The second changes is a refactoring of the code that now allows you to compute through the setting of flags any combination of the image, time slope and trigger fraction templates. This especially useful when the image templates are not needed as it skips the neural network fit. All computation of fraction and time templates that was previously there is taken out of the NNFitter class which now only handles the image templates.