### PR TITLE
Add telescope string to saved templates

### DIFF
--- a/template_builder/nn_fitter.py
+++ b/template_builder/nn_fitter.py
@@ -165,7 +165,7 @@ class NNFitter(Component):
 
         return model_pred.reshape((self.bins[1], self.bins[0])).T
 
-    def generate_image_templates(self, x, y, amplitude, output_file="./Template"):
+    def generate_image_templates(self, x, y, amplitude, tel_type, output_file="./Template"):
         """
 
         :param file_list: list
@@ -184,7 +184,10 @@ class NNFitter(Component):
         """
         templates = self.fit_templates(x, y, amplitude)
         file_handler = gzip.open(output_file + ".template.gz", "wb")
-        pickle.dump(templates, file_handler)
+        final_out_dict={}
+        final_out_dict["data"]=templates
+        final_out_dict["tel_type"]=tel_type
+        pickle.dump(final_out_dict, file_handler)
         file_handler.close()
 
         correction_factor = self.calculate_correction_factors(
@@ -193,7 +196,10 @@ class NNFitter(Component):
         for t in templates:
             templates[t] = templates[t] * correction_factor
         file_handler = gzip.open(output_file + "_corrected.template.gz", "wb")
-        pickle.dump(templates, file_handler)
+        final_out_dict={}
+        final_out_dict["data"]=templates
+        final_out_dict["tel_type"]=tel_type
+        pickle.dump(final_out_dict, file_handler)
         file_handler.close()
 
         return True

--- a/template_builder/template_fitter.py
+++ b/template_builder/template_fitter.py
@@ -197,6 +197,10 @@ class TemplateFitter(Tool):
             )
             sys.exit(1)
 
+        assert len(self.event_source.subarray.telescope_types)==1, "The event source should only contain one telescope type"
+
+        self.telescope_type=str(self.event_source.subarray.telescope_types[0])
+
         self.calibrate = CameraCalibrator(
             parent=self, subarray=self.event_source.subarray
         )
@@ -304,6 +308,7 @@ class TemplateFitter(Tool):
                 self.templates_xb,
                 self.templates_yb,
                 self.templates,
+                tel_type=self.telescope_type,
                 output_file=self.output_file,
             )
         if self.time_computation:
@@ -521,7 +526,11 @@ class TemplateFitter(Tool):
                 )
 
         file_handler = gzip.open(self.output_file + "_time.template.gz", "wb")
-        pickle.dump(time_slope_template, file_handler)
+
+        final_out_dict={}
+        final_out_dict["data"]=time_slope_template
+        final_out_dict["tel_type"]=self.telescope_type
+        pickle.dump(final_out_dict, file_handler)
         file_handler.close()
 
     def generate_fraction_templates(self):
@@ -529,7 +538,10 @@ class TemplateFitter(Tool):
         for key in self.count.keys():
             fraction[key] = self.count[key] / self.count_total
         file_handler = gzip.open(self.output_file + "_fraction.template.gz", "wb")
-        pickle.dump(fraction, file_handler)
+        final_out_dict={}
+        final_out_dict["data"]=fraction
+        final_out_dict["tel_type"]=self.telescope_type
+        pickle.dump(final_out_dict, file_handler)
         file_handler.close()
 
 


### PR DESCRIPTION
Hi @ParsonsRD ,

I'm working on some cleanups of ImPACT in ctapipe, and one of them is to include into the template dict the string description of the telescope it is used for. This will then be checked by ctapipe to determine whether the templates that are being used are actually valid. I've changed the template creation routine so this description string is always included.